### PR TITLE
replace "ID" to "Id",  and  add API to get single tutorial

### DIFF
--- a/go-gin/controllers/tutorial_controller.go
+++ b/go-gin/controllers/tutorial_controller.go
@@ -16,8 +16,8 @@ import (
 
 func GetAllTutorials() gin.HandlerFunc {
 	return func(c *gin.Context) {
-        ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-        defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
 
 		client := configs.ConnectDB()
 		collection := client.Database("tutorial").Collection("tutorial_collection")
@@ -49,10 +49,41 @@ func GetAllTutorials() gin.HandlerFunc {
 	}
 }
 
+func GetTutorial() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		client := configs.ConnectDB()
+		collection := client.Database("tutorial").Collection("tutorial_collection")
+
+		id := c.Param("id")
+		println(id)
+
+		objId, _ := primitive.ObjectIDFromHex(id)
+
+		//get updated tutorial details
+		var tutorial models.Tutorial
+		err := collection.FindOne(ctx, bson.M{"_id": objId}).Decode(&tutorial)
+		if err != nil {
+			panic(err)
+		}
+
+		output, err := json.MarshalIndent(tutorial, "", "    ")
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("%s\n", output)
+
+		c.IndentedJSON(http.StatusOK, tutorial)
+
+	}
+}
+
 func CreateTutorial() gin.HandlerFunc {
 	return func(c *gin.Context) {
-        ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-        defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
 
 		client := configs.ConnectDB()
 		collection := client.Database("tutorial").Collection("tutorial_collection")
@@ -84,17 +115,17 @@ func CreateTutorial() gin.HandlerFunc {
 
 func UpdateTutorial() gin.HandlerFunc {
 	return func(c *gin.Context) {
-        ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-        defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
 
 		client := configs.ConnectDB()
 		collection := client.Database("tutorial").Collection("tutorial_collection")
 
-		ID := c.Param("id")
-		println(ID)
+		id := c.Param("id")
+		println(id)
 		var tutorial models.Tutorial
-		
-		objId, _ := primitive.ObjectIDFromHex(ID)
+
+		objId, _ := primitive.ObjectIDFromHex(id)
 
 		if err := c.BindJSON(&tutorial); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"message": err})
@@ -136,8 +167,8 @@ func UpdateTutorial() gin.HandlerFunc {
 
 func DeleteTutorial() gin.HandlerFunc {
 	return func(c *gin.Context) {
-        ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-        defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
 
 		client := configs.ConnectDB()
 		collection := client.Database("tutorial").Collection("tutorial_collection")

--- a/go-gin/models/tutorial_model.go
+++ b/go-gin/models/tutorial_model.go
@@ -8,5 +8,5 @@ type Tutorial struct {
 	Published   bool               `json:"published"`
 	CreatedAt   string             `json:"createdAt"`
 	UpdatedAt   string             `json:"updatedAt"`
-	ID          primitive.ObjectID `bson:"_id"`
+	Id          primitive.ObjectID `bson:"_id"`
 }

--- a/go-gin/routes/tutorial_route.go
+++ b/go-gin/routes/tutorial_route.go
@@ -8,6 +8,7 @@ import (
 
 func TutorialRoute(router *gin.Engine) {
 	router.GET("/api/tutorials", controllers.GetAllTutorials())
+	router.GET("/api/tutorials/:id", controllers.GetTutorial())
 	router.POST("/api/tutorials", controllers.CreateTutorial())
 	router.PUT("/api/tutorials/:id", controllers.UpdateTutorial())
 	router.DELETE("/api/tutorials/:id", controllers.DeleteTutorial())

--- a/vue-js/src/components/AddTutorial.vue
+++ b/vue-js/src/components/AddTutorial.vue
@@ -42,7 +42,7 @@
     data() {
       return {
         tutorial: {
-          id: null,
+          Id: null,
           title: "",
           description: "",
           published: false
@@ -59,7 +59,7 @@
   
         TutorialDataService.create(data)
           .then(response => {
-            this.tutorial.id = response.data.id;
+            this.tutorial.Id = response.data.Id;
             console.log(response.data);
             this.submitted = true;
           })

--- a/vue-js/src/components/Tutorial.vue
+++ b/vue-js/src/components/Tutorial.vue
@@ -76,16 +76,16 @@
             console.log(e);
           });
       },
-  
+      
       updatePublished(status) {
         var data = {
-          id: this.currentTutorial.id,
+          Id: this.currentTutorial.Id,
           title: this.currentTutorial.title,
           description: this.currentTutorial.description,
           published: status
         };
   
-        TutorialDataService.update(this.currentTutorial.id, data)
+        TutorialDataService.update(this.currentTutorial.Id, data)
           .then(response => {
             this.currentTutorial.published = status;
             console.log(response.data);
@@ -96,7 +96,7 @@
       },
   
       updateTutorial() {
-        TutorialDataService.update(this.currentTutorial.id, this.currentTutorial)
+        TutorialDataService.update(this.currentTutorial.Id, this.currentTutorial)
           .then(response => {
             console.log(response.data);
             this.message = 'The tutorial was updated successfully!';
@@ -107,7 +107,7 @@
       },
   
       deleteTutorial() {
-        TutorialDataService.delete(this.currentTutorial.id)
+        TutorialDataService.delete(this.currentTutorial.Id)
           .then(response => {
             console.log(response.data);
             this.$router.push({ name: "tutorials" });
@@ -119,7 +119,7 @@
     },
     mounted() {
       this.message = '';
-      this.getTutorial(this.$route.params.id);
+      this.getTutorial(this.$route.params.Id);
     }
   };
   </script>

--- a/vue-js/src/components/TutorialsList.vue
+++ b/vue-js/src/components/TutorialsList.vue
@@ -44,7 +44,7 @@
           </div>
   
           <a class="badge badge-warning"
-            :href="'/tutorials/' + currentTutorial.id"
+            :href="'/tutorials/' + currentTutorial.Id"
           >
             Edit
           </a>

--- a/vue-js/src/router.js
+++ b/vue-js/src/router.js
@@ -13,7 +13,7 @@ export default new Router({
       component: () => import("./components/TutorialsList")
     },
     {
-      path: "/tutorials/:id",
+      path: "/tutorials/:Id",
       name: "tutorial-details",
       component: () => import("./components/Tutorial")
     },

--- a/vue-js/src/services/TutorialDataService.js
+++ b/vue-js/src/services/TutorialDataService.js
@@ -5,20 +5,20 @@ class TutorialDataService {
     return http.get("/tutorials");
   }
 
-  get(id) {
-    return http.get(`/tutorials/${id}`);
+  get(Id) {
+    return http.get(`/tutorials/${Id}`);
   }
 
   create(data) {
     return http.post("/tutorials", data);
   }
 
-  update(id, data) {
-    return http.put(`/tutorials/${id}`, data);
+  update(Id, data) {
+    return http.put(`/tutorials/${Id}`, data);
   }
 
-  delete(id) {
-    return http.delete(`/tutorials/${id}`);
+  delete(Id) {
+    return http.delete(`/tutorials/${Id}`);
   }
 
   deleteAll() {


### PR DESCRIPTION
# What we do in this PR
- The variable name ID (upper case) that held the primary key in the server-side go controller was changed to id (lower case) because it was unnatural.

- The variable name ID of the model of go on the server side was changed to Id. (The leading capital letter is [a constraint on the variable name of the model](https://chat.openai.com/share/71ae7dce-5e1e-4d62-a240-9559cf655b0c).)

- The variable id on the client side was changed to Id to make it consistent with automatic mapping.

- Added API to retrieve a single tutorial.

# What we would like reviewer to check
- You can go from the tutorial list page to the detail page.
- Tutorials can be edited from the detail page.
- Tutorials can be published from the detail page.
- Tutorials can be un-published from the detail page.
- Tutorials can be deleted from the detail page.



# Screen shots
<img width="764" alt="image" src="https://github.com/toshi-nao/web-app-sample/assets/1375346/3284647e-ae58-4bf4-9a60-496ef3222aa5">

---

<img width="924" alt="image" src="https://github.com/toshi-nao/web-app-sample/assets/1375346/d7491558-bd29-45b2-a3b9-5a6da40b5892">

---
<img width="834" alt="image" src="https://github.com/toshi-nao/web-app-sample/assets/1375346/436eb9b5-a4d4-4c95-b66d-dfc033578f44">

---
